### PR TITLE
FIX check upload error

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "tiloweb/uploaded-file-type-bundle",
+    "name": "salvatorepandolfi/uploaded-file-type-bundle",
     "description": "A Symfony bundle that handle the form FileType upload and store the URL for you",
     "type": "symfony-bundle",
     "license": "MIT",

--- a/src/Form/UploadedFileTypeExtension.php
+++ b/src/Form/UploadedFileTypeExtension.php
@@ -81,7 +81,7 @@ class UploadedFileTypeExtension implements FormTypeExtensionInterface
                 $uploadedFile = $event->getData();
                 $item = $event->getForm()->getParent()->getData();
 
-                if(!$uploadedFile) {
+                if(!$uploadedFile || ($uploadedFile instanceof UploadedFile && $uploadedFile->getError() !== UPLOAD_ERR_OK)) {
                     return;
                 }
 


### PR DESCRIPTION
If an error occur during the file upload the UploadedFile object is sent nevertheless.
This PR solve the issue checking if the UploadedFile object encounter an error.